### PR TITLE
Add simple progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ SPDX-License-Identifier: Apache-2.0
 This is an oc plugin simulating cluster failures by making a cluster
 unreachable from other clusters.
 
+[![asciicast](https://asciinema.org/a/626178.svg)](https://asciinema.org/a/626178)
+
 ## Quick start
 
 Assuming a system with 3 clusters:

--- a/cmd/block.go
+++ b/cmd/block.go
@@ -14,12 +14,7 @@ var blockCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		blockedContext := args[0]
 
-		c, err := NewCommand(blockedContext, targetContexts, kubeconfig)
-		if err != nil {
-			errlog.Fatal(err)
-		}
-
-		err = c.InspectClusters()
+		c, err := NewCommand(blockedContext, targetContexts, kubeconfig, showProgress)
 		if err != nil {
 			errlog.Fatal(err)
 		}

--- a/cmd/progress.go
+++ b/cmd/progress.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: The oc-blackhole authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+)
+
+type Progress struct {
+	mutex       sync.Mutex
+	description string
+	tasks       uint
+	done        uint
+	width       int
+	out         io.Writer
+}
+
+// NewProgress return a new progress indicator.
+func NewProgress(descripiton string, tasks uint, out io.Writer) *Progress {
+	p := &Progress{
+		description: descripiton,
+		tasks:       tasks,
+		width:       80,
+		out:         out,
+	}
+	p.update()
+	return p
+}
+
+// SetTasks changes the number of tasks.
+func (p *Progress) SetTasks(tasks uint) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	if p.tasks != tasks {
+		p.tasks = tasks
+		p.update()
+	}
+}
+
+// SetDescription changes the description.
+func (p *Progress) SetDescription(desciption string) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	if p.description != desciption {
+		p.description = desciption
+		p.update()
+	}
+}
+
+// Add completed tasks to progress.
+func (p *Progress) Add(completed uint) {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	if p.done < p.tasks {
+		p.done = min(p.done+completed, p.tasks)
+		p.update()
+	}
+}
+
+// Clear the progress output.
+func (p *Progress) Clear() {
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
+	line := strings.Repeat(" ", p.width-1) + "\r"
+	p.out.Write([]byte(line))
+}
+
+func (p *Progress) update() {
+	// Padd output to full line to cover previous line data
+	padding := strings.Repeat(" ", p.width-1-len(p.description)-len("[ ---- ] "))
+
+	var line string
+	if p.tasks == 0 {
+		line = fmt.Sprintf("[ ---- ] %s%s\r", p.description, padding)
+	} else {
+		value := float64(p.done*100) / float64(p.tasks)
+		line = fmt.Sprintf("[ %3.0f%% ] %s%s\r", value, p.description, padding)
+	}
+
+	p.out.Write([]byte(line))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 var targetContexts []string
 var kubeconfig string
 var verbose bool
+var showProgress bool
 
 var example = `  # Make cluster 'foo' unreachable from clusters 'bar' and 'baz':
   oc blackhole block foo --contexts bar,baz
@@ -51,4 +52,6 @@ func init() {
 		"the kubeconfig file to use")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false,
 		"be more verbose")
+	rootCmd.PersistentFlags().BoolVarP(&showProgress, "progress", "p", false,
+		"show progress")
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -17,12 +17,7 @@ var showCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		blockedContext := args[0]
 
-		c, err := NewCommand(blockedContext, targetContexts, kubeconfig)
-		if err != nil {
-			errlog.Fatal(err)
-		}
-
-		err = c.InspectClusters()
+		c, err := NewCommand(blockedContext, targetContexts, kubeconfig, showProgress)
 		if err != nil {
 			errlog.Fatal(err)
 		}

--- a/cmd/unblock.go
+++ b/cmd/unblock.go
@@ -14,12 +14,7 @@ var unblockCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		blockedContext := args[0]
 
-		c, err := NewCommand(blockedContext, targetContexts, kubeconfig)
-		if err != nil {
-			errlog.Fatal(err)
-		}
-
-		err = c.InspectClusters()
+		c, err := NewCommand(blockedContext, targetContexts, kubeconfig, showProgress)
 		if err != nil {
 			errlog.Fatal(err)
 		}

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: The oc-blackhole authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+oc-blackhole demo.
+
+Installing requirements:
+
+    python3 -m venv ~/.venv/oc-blackhole
+    source ~/.venv/oc-blackhole/bin/activate
+    pip install --upgrade pip nohands
+
+Run using:
+
+    python3 demo.py
+
+"""
+
+from nohands import *
+
+run("clear")
+msg("### OC BLACKHOLE PLUGIN DEMO ###", color=YELLOW)
+msg()
+msg("We have 3 OpenShift clusters: 'perf1', 'perf2', and 'perf3'.")
+msg("Let's make cluster 'perf2' unreachable from other clusters:")
+msg()
+run("oc", "blackhole", "block", "perf2", "--progress", "--contexts", "perf1,perf3")
+msg()
+msg("What happened? we can show the cluster status:")
+msg()
+run("oc", "blackhole", "show", "perf2", "--progress", "--contexts", "perf1,perf3")
+msg()
+msg("Let's test how the system handles the unreachable cluster.")
+msg("We can use the rook-ceph oc plugin to check dr health:")
+msg()
+run("oc", "rook-ceph", "-n", "openshift-storage", "--context", "perf3", "dr", "health")
+msg()
+msg("Ceph is not happy!")
+msg("Let's make cluster 'perf2' reachable again:")
+msg()
+run("oc", "blackhole", "unblock", "perf2", "--progress", "--contexts", "perf1,perf3")
+msg()
+msg("Now we can test how the system handles the recovered cluster.")
+msg()
+msg("Created with https://pypi.org/project/nohands/", color=GREY)


### PR DESCRIPTION
Add a very simple multi-phase progress, showing each phase of the command.

Using multiple phases we don't need to think how to compute the progress for
the entire operation.

[![asciicast](https://asciinema.org/a/626182.svg)](https://asciinema.org/a/626182)

Fixes #10