### PR TITLE
Add Go reference badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 # oc-blackhole
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/nirs/oc-blackhole.svg)](https://pkg.go.dev/github.com/nirs/oc-blackhole)
+
 This is an oc plugin simulating cluster failures by making a cluster
 unreachable from other clusters.
 


### PR DESCRIPTION
It is cool that we get automatic docs in pkg.go.dev:
https://pkg.go.dev/github.com/nirs/oc-blackhole@v0.1.0/cmd

Currently the docs are not really useful since the code is not designed to be used as a library but I like the badge.